### PR TITLE
fix(ci): Fix workflow triggers

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - trunk
-  pull_request:
-    branches:
-      - trunk
-  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Build and Push workflow should not run for pull request and merge queue - registry pushes should happen only on pushes to `trunk`.
