### PR TITLE
chore(deps): Downgrade @devcontainers/cli to 0.35.0

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -78,7 +78,7 @@ jobs:
           password: ${{ secrets.WPCOM_VIP_BOT_TOKEN }}
 
       - name: Install @devcontainers/cli
-        run: npm install -g @devcontainers/cli
+        run: npm install -g @devcontainers/cli@0.35.0
 
       - name: Publish features
         run: devcontainer features publish features/src --namespace "${{ github.repository }}"
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.WPCOM_VIP_BOT_TOKEN }}
 
       - name: Install @devcontainers/cli
-        run: npm install -g @devcontainers/cli
+        run: npm install -g @devcontainers/cli@0.35.0
 
       - name: Publish templates
         run: devcontainer templates publish templates/src --namespace "${{ github.repository }}"


### PR DESCRIPTION
```
[2023-04-04T00:16:52.219Z] [httpOci] Applying cachedAuthHeader for registry ghcr.io...
[2023-04-04T00:16:52.311Z] [httpOci] Attempting to authenticate via 'Bearer' auth.
[2023-04-04T00:16:52.312Z] [httpOci] Failed to read docker config.json: TypeError: Cannot convert undefined or null to object
```

This started to appear in 0.36.0
