### PR TITLE
fix(vip-cli): Fall back to edge/main to install Node.js

### DIFF
--- a/features/src/vip-cli/devcontainer-feature.json
+++ b/features/src/vip-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "id": "vip-cli",
     "name": "VIP CLI",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Installs VIP CLI into the Dev Environment",
     "options": {
         "enabled": {

--- a/features/src/vip-cli/install.sh
+++ b/features/src/vip-cli/install.sh
@@ -13,7 +13,11 @@ fi
 
 if [ "${ENABLED}" = "true" ]; then
     echo '(*) Installing VIP CLI...'
-    apk add --no-cache nodejs npm
+    if ! grep -Eq '^@edgem' /etc/apk/repositories; then
+        echo "@edgem https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
+    fi
+
+    apk add --no-cache nodejs npm || apk add --no-cache nodejs@edgem npm@edgem
     npm i -g @automattic/vip
     echo 'Done!'
 fi


### PR DESCRIPTION
```
#39 0.382 (*) Installing VIP CLI...
#39 0.392 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
#39 0.950 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
#39 1.601 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#39 1.759 fetch https://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
#39 2.157 ERROR: unable to select packages:
#39 2.236   nodejs-18.16.0-r1:
#39 2.236     masked in: @edgem
#39 2.236     satisfies: world[nodejs]
#39 2.236                npm-9.1.2-r0[cmd:node]
#39 2.236 ERROR: Feature "./.devcontainer/features/vip-cli" (Unknown) failed to install!
#39 ERROR: process "/bin/sh -c chmod -R 0755 /tmp/dev-container-features/vip-cli_10 && cd /tmp/dev-container-features/vip-cli_10 && chmod +x ./devcontainer-features-install.sh && ./devcontainer-features-install.sh" did not complete successfully: exit code: 2
```

This happens because both `php8-intl` and `nodejs` depend on `libicu`. Because of this, we have may have to install `nodejs` from `edge/main`.