### PR TITLE
fix(php): php82-pecl-memcache moved from testing to community

### DIFF
--- a/features/src/php/devcontainer-feature.json
+++ b/features/src/php/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "php",
     "name": "PHP",
     "description": "Installs PHP into the Dev Environment",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "containerEnv": {
         "PHP_INI_DIR": "/etc/php",
         "COMPOSER_ALLOW_SUPERUSER": "1"

--- a/features/src/php/install.sh
+++ b/features/src/php/install.sh
@@ -179,7 +179,7 @@ setup_php82() {
         php82-intl@edgec \
         php82-mbstring@edgec \
         php82-pecl-igbinary@edgec \
-        php82-pecl-memcache@edget \
+        php82-pecl-memcache@edgec \
         php82-pecl-memcached@edgec \
         php82-pecl-mcrypt@edget \
         php82-mysqli@edgec \


### PR DESCRIPTION
```
#16 0.061 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/x86_64/APKINDEX.tar.gz
#16 0.186 fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/x86_64/APKINDEX.tar.gz
#16 0.321 fetch https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz
#16 0.363 fetch https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/APKINDEX.tar.gz
#16 0.497 fetch https://dl-cdn.alpinelinux.org/alpine/edge/testing/x86_64/APKINDEX.tar.gz
#16 0.800 ERROR: unable to select packages:
#16 0.887   php82-pecl-memcache-8.2-r0:
#16 0.887     masked in: @edgec
#16 0.887     satisfies: world[php82-pecl-memcache]
#16 0.888 ERROR: Feature "./.devcontainer/features/php" (Unknown) failed to install!
```
