### PR TITLE
fix(wordpress): Do not wait for Elasticsearch more than one minute

### DIFF
--- a/features/src/wordpress/devcontainer-feature.json
+++ b/features/src/wordpress/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "wordpress",
     "name": "WordPress",
     "description": "Sets up WordPress into the Dev Environment",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "containerEnv": {
         "WP_CLI_CONFIG_PATH": "/etc/wp-cli/wp-cli.yaml"
     },

--- a/features/src/wordpress/setup-wordpress.sh
+++ b/features/src/wordpress/setup-wordpress.sh
@@ -140,7 +140,7 @@ if ! wp core is-installed >/dev/null 2>&1; then
     if [ -e /etc/service/elasticsearch ] && wp cli has-command vip-search; then
         echo "Waiting for Elasticsearch to come online..."
         second=0
-        while ! curl -s 'http://127.0.0.1:9200/_cluster/health' > /dev/null; do
+        while ! curl -s 'http://127.0.0.1:9200/_cluster/health' > /dev/null && [ "${second}" -lt 60 ]; do
             sleep 1
             second=$((second+1))
         done


### PR DESCRIPTION
Ref: https://github.com/Automattic/vip-container-images/pull/479
