### PR TITLE
feat(vip-go-mu-plugins): Allow for installing vip-go-mu-plugins from the specified branch

### DIFF
--- a/features/src/vip-go-mu-plugins/devcontainer-feature.json
+++ b/features/src/vip-go-mu-plugins/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "id": "vip-go-mu-plugins",
     "name": "VIP Go MU Plugins",
-    "version": "1.0.1",
+    "version": "2.0.0",
     "description": "Installs VIP Go MU Plugins into the Dev Environment",
     "options": {
         "enabled": {
@@ -9,10 +9,25 @@
             "default": true,
             "description": "Whether to install VIP Go MU Plugins"
         },
-        "retainGit": {
+        "branch": {
+            "type": "string",
+            "default": "staging",
+            "description": "Which branch to install from",
+            "enum": [
+                "staging",
+                "production",
+                "develop"
+            ]
+        },
+        "retain_git": {
             "type": "boolean",
             "default": false,
             "description": "Whether to retain the .git directory"
+        },
+        "delete_unnecessary_files": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to delete unnecessary files (like tests, dotfiles, etc). It is recommended to set this to false if retain_git is true."
         }
     },
     "installsAfter": [

--- a/test/devcontainer-php80.json
+++ b/test/devcontainer-php80.json
@@ -25,7 +25,8 @@
         },
         "./.devcontainer/features/vip-go-mu-plugins": {
             "enabled": true,
-            "retainGit": true
+            "retain_git": false,
+            "delete_unnecessary_files": true
         },
         "./.devcontainer/features/dev-tools": {},
         "./.devcontainer/features/elasticsearch": {

--- a/test/devcontainer-php81.json
+++ b/test/devcontainer-php81.json
@@ -25,7 +25,8 @@
         },
         "./.devcontainer/features/vip-go-mu-plugins": {
             "enabled": true,
-            "retainGit": true
+            "retain_git": false,
+            "delete_unnecessary_files": true
         },
         "./.devcontainer/features/dev-tools": {},
         "./.devcontainer/features/elasticsearch": {

--- a/test/devcontainer-php82.json
+++ b/test/devcontainer-php82.json
@@ -25,7 +25,8 @@
         },
         "./.devcontainer/features/vip-go-mu-plugins": {
             "enabled": true,
-            "retainGit": true
+            "retain_git": false,
+            "delete_unnecessary_files": true
         },
         "./.devcontainer/features/dev-tools": {},
         "./.devcontainer/features/elasticsearch": {


### PR DESCRIPTION
Closes: #50
Ref: DOC-10163

Added:
* `branch` option: can be `develop`, `staging`, or `production`. This is the branch to clone `vip-go-mu-plugins` from;
* `delete_unnecessary_files`: when set to `true`, the script will try to delete unnecessary files (tests, docs, CI, etc).

Renamed:
* `retaingit` to `retain_git`.

If `retain_git` is `true`, it makes sense to set `delete_unnecessary_files` to `false`. This combination can be useful if someone wants to contribute to `vip-go-mu-plugins`.
