### PR TITLE
fix(php): temporarily disable gmagick for PHP 8.3

### DIFF
--- a/features/src/php/devcontainer-feature.json
+++ b/features/src/php/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "php",
     "name": "PHP",
     "description": "Installs PHP into the Dev Environment",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "containerEnv": {
         "PHP_INI_DIR": "/etc/php"
     },

--- a/features/src/php/install.sh
+++ b/features/src/php/install.sh
@@ -252,7 +252,7 @@ setup_php83() {
 
     apk del --no-cache php83-dev gcc make libc-dev graphicsmagick-dev libtool libmemcached-dev
 
-    echo "extension=gmagick.so" > /etc/php83/conf.d/40_gmagick.ini
+    # echo "extension=gmagick.so" > /etc/php83/conf.d/40_gmagick.ini
     echo "extension=memcache.so" > /etc/php83/conf.d/40_memcache.ini
     echo "extension=memcached.so" > /etc/php83/conf.d/40_memcached.ini
     echo "extension=timezonedb.so" > /etc/php83/conf.d/40_timezonedb.ini


### PR DESCRIPTION
> 0.095 Magick: abort due to signal 11 (SIGSEGV) "Segmentation Fault"...
> 0.373 Aborted (core dumped)
