### PR TITLE
ci: properly handle force pushes

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -44,14 +44,18 @@ jobs:
         id: changes
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            base="${{ github.event.before }}"
-            head="${{ github.event.after }}"
-            image="images/src/${{ matrix.image.image-name }}"
-            changes="$(git diff --name-only "${base}" "${head}" -- "${image}" | grep -Fv "${image}/README.md" || true)"
-            if [ -n "${changes}" ]; then
+            if [ "${{ github.event.forced }}" = "true" ]; then
               echo needs_build=true >> "${GITHUB_OUTPUT}"
             else
-              echo needs_build=false >> "${GITHUB_OUTPUT}"
+              base="${{ github.event.before }}"
+              head="${{ github.event.after }}"
+              image="images/src/${{ matrix.image.image-name }}"
+              changes="$(git diff --name-only "${base}" "${head}" -- "${image}" | grep -Fv "${image}/README.md" || true)"
+              if [ -n "${changes}" ]; then
+                echo needs_build=true >> "${GITHUB_OUTPUT}"
+              else
+                echo needs_build=false >> "${GITHUB_OUTPUT}"
+              fi
             fi
           else
             echo needs_build=true >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
When a branch is force-pushed to, `github.event.before` is set to the overwritten reference. As a result, `git diff` fails and reports no changes, event if there are some.
