### PR TITLE
feat: add su-exec feature

### DIFF
--- a/features/src/su-exec/devcontainer-feature.json
+++ b/features/src/su-exec/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+    "id": "su-exec",
+    "name": "su-exec",
+    "version": "1.0.0",
+    "description": "Provides su-exec for running commands as another user"
+}

--- a/features/src/su-exec/install.sh
+++ b/features/src/su-exec/install.sh
@@ -29,15 +29,15 @@ case "${ID_LIKE}" in
             PACKAGES="${PACKAGES} libc6-dev"
         fi
 
-        if ! which cc >/dev/null 2>&1; then
+        if ! hash cc >/dev/null 2>&1; then
             PACKAGES="${PACKAGES} tcc"
         fi
 
-        if ! which wget >/dev/null 2>&1; then
+        if ! hash wget >/dev/null 2>&1; then
             PACKAGES="${PACKAGES} wget"
         fi
 
-        if ! which update-ca-certificates >/dev/null 2>&1; then
+        if ! hash update-ca-certificates >/dev/null 2>&1; then
             PACKAGES="${PACKAGES} ca-certificates"
         fi
 

--- a/features/src/su-exec/install.sh
+++ b/features/src/su-exec/install.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -e
+
+PATH=/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin
+
+if [ "$(id -u || true)" -ne 0 ]; then
+    echo 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+    exit 1
+fi
+
+echo '(*) Installing su-exec...'
+
+# shellcheck source=/dev/null
+. /etc/os-release
+
+: "${ID:=}"
+: "${ID_LIKE:=${ID}}"
+
+if [ -z "${ID}" ]; then
+    echo 'Unable to determine the distribution.'
+    exit 1
+fi
+
+case "${ID_LIKE}" in
+    "debian")
+        PACKAGES=""
+        if ! dpkg -s libc6-dev >/dev/null 2>&1; then
+            PACKAGES="${PACKAGES} libc6-dev"
+        fi
+
+        if ! which cc >/dev/null 2>&1; then
+            PACKAGES="${PACKAGES} tcc"
+        fi
+
+        if ! which wget >/dev/null 2>&1; then
+            PACKAGES="${PACKAGES} wget"
+        fi
+
+        if ! which update-ca-certificates >/dev/null 2>&1; then
+            PACKAGES="${PACKAGES} ca-certificates"
+        fi
+
+        if [ -n "${PACKAGES}" ]; then
+            apt-get update
+            # shellcheck disable=SC2086
+            apt-get install -y --no-install-recommends ${PACKAGES}
+        fi
+
+        wget -q https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c -O su-exec.c
+        cc -O2 su-exec.c -o /usr/local/bin/su-exec
+        rm su-exec.c
+
+        if [ -n "${PACKAGES}" ]; then
+            # shellcheck disable=SC2086
+            apt-get purge -y --auto-remove ${PACKAGES}
+            apt-get clean
+            rm -rf /var/lib/apt/lists/*
+        fi
+    ;;
+
+    "alpine")
+        apk add --no-cache su-exec
+    ;;
+
+    *)
+        echo "(!) Unsupported distribution: ${ID}"
+        exit 1
+    ;;
+esac
+
+echo 'Done!'

--- a/features/test/su-exec/test.sh
+++ b/features/test/su-exec/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# shellcheck source=/dev/null
+source dev-container-features-test-lib
+
+check "su-exec exists" sh -c "which su-exec"
+
+reportResults


### PR DESCRIPTION
This PR adds a `su-exec` feature for running commands as another user. We need it to minimize modifications to features to support Debian/Ubuntu images.
