### PR TITLE
revert: bump alpine from 3.19.1 to 3.20.0 in /images/src/alpine-base

### DIFF
--- a/images/src/alpine-base/.devcontainer.json
+++ b/images/src/alpine-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "Alpine",
         "image-name": "alpine-base",
-        "image-version": "1.6.0"
+        "image-version": "1.5.2"
     },
     "remoteUser": "vscode"
 }

--- a/images/src/alpine-base/.devcontainer.json
+++ b/images/src/alpine-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "Alpine",
         "image-name": "alpine-base",
-        "image-version": "1.5.2"
+        "image-version": "1.6.1"
     },
     "remoteUser": "vscode"
 }

--- a/images/src/alpine-base/Dockerfile
+++ b/images/src/alpine-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.20.0
+FROM alpine:3.19.1
 
 ARG USERNAME=vscode
 ARG USER_UID=1000


### PR DESCRIPTION
Reverts Automattic/vip-codespaces#176