### PR TITLE
fix(wordpress): reset permissions of `/wp/wp-content` in the installer

### DIFF
--- a/features/src/wordpress/devcontainer-feature.json
+++ b/features/src/wordpress/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "wordpress",
     "name": "WordPress",
     "description": "Sets up WordPress into the Dev Environment",
-    "version": "2.3.3",
+    "version": "2.3.4",
     "containerEnv": {
         "WP_CLI_CONFIG_PATH": "/etc/wp-cli/wp-cli.yaml"
     },

--- a/features/src/wordpress/setup-wordpress.sh
+++ b/features/src/wordpress/setup-wordpress.sh
@@ -56,6 +56,7 @@ done
 
 if [ -n "${WP_PERSIST_UPLOADS}" ]; then
     sudo install -d -o "${MY_UID}" -g "${MY_GID}" -m 0755 /workspaces/uploads
+    sudo install -d -o "${MY_UID}" -g "${MY_GID}" -m 0755 /wp/wp-content
     ln -sf /workspaces/uploads /wp/wp-content/uploads
 else
     sudo install -d -o "${MY_UID}" -g "${MY_GID}" -m 0755 /wp/wp-content/uploads


### PR DESCRIPTION
This fixes the "ln: failed to create symbolic link '/wp/wp-content/uploads': Permission denied" error.

The error happens when `$_REMOTE_USER`'s UID differs from the UID of the host user that builds the image.

Ref: https://github.com/Automattic/vip-codespaces/actions/runs/9313223556/job/25635298210?pr=181#step:6:1311