### PR TITLE
chore(deps): update `wpvip-base` image

### DIFF
--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -25,10 +25,10 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:13b301a039ce9e0bb07d45ea0c106c946cfff01c3b9844bbec6b0c7bacba8de3",
       "integrity": "sha256:13b301a039ce9e0bb07d45ea0c106c946cfff01c3b9844bbec6b0c7bacba8de3"
     },
-    "ghcr.io/devcontainers/features/node:1.6.0": {
-      "version": "1.6.0",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:902b97a02d04ffd3404579d793f3e101d1126d4d198929196c5872ed75a6d351",
-      "integrity": "sha256:902b97a02d04ffd3404579d793f3e101d1126d4d198929196c5872ed75a6d351"
+    "ghcr.io/devcontainers/features/node:1.6.1": {
+      "version": "1.6.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:71590121aaf7b2040f3e1e2dfc4bb9a1389277fd5a88a7199094542b82ce5340",
+      "integrity": "sha256:71590121aaf7b2040f3e1e2dfc4bb9a1389277fd5a88a7199094542b82ce5340"
     }
   }
 }

--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -10,10 +10,10 @@
       "resolved": "ghcr.io/devcontainers-contrib/features/composer@sha256:672688d643dc534d73a97b406746363e0206889e3360a3235aff5cac75368c98",
       "integrity": "sha256:672688d643dc534d73a97b406746363e0206889e3360a3235aff5cac75368c98"
     },
-    "ghcr.io/devcontainers/features/common-utils:2.5.1": {
-      "version": "2.5.1",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:9da676524999513412f2c27604d786ba0bbf3575eb1859166c5a1233f037fc08",
-      "integrity": "sha256:9da676524999513412f2c27604d786ba0bbf3575eb1859166c5a1233f037fc08"
+    "ghcr.io/devcontainers/features/common-utils:2.5.2": {
+      "version": "2.5.2",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:5b1c376d30719a4dead8fb2f272ee496cfb506f2f92b7acf9e1c24cb5399ba7d",
+      "integrity": "sha256:5b1c376d30719a4dead8fb2f272ee496cfb506f2f92b7acf9e1c24cb5399ba7d"
     },
     "ghcr.io/devcontainers/features/git:1.3.2": {
       "version": "1.3.2",

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "WPVIP",
         "image-name": "wpvip-base",
-        "image-version": "0.0.18"
+        "image-version": "0.0.19"
     },
     "remoteUser": "vscode",
     "postStartCommand": "/usr/local/bin/post-start.sh",

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -11,7 +11,7 @@
     "remoteUser": "vscode",
     "postStartCommand": "/usr/local/bin/post-start.sh",
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.1": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.2": {
             "installZsh": false,
             "installOhMyZsh": false,
             "installOhMyZshConfig": false,

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -20,7 +20,7 @@
         },
         "ghcr.io/devcontainers/features/git:1.3.2": {},
         "ghcr.io/devcontainers/features/github-cli:1.0.13": {},
-        "ghcr.io/devcontainers/features/node:1.6.0": {},
+        "ghcr.io/devcontainers/features/node:1.6.1": {},
         "ghcr.io/devcontainers-contrib/features/composer:1.0.0": {},
         "ghcr.io/automattic/vip-codespaces/wp-cli:1.1.4": {},
         "./.devcontainer/local-features/sudo": {}


### PR DESCRIPTION
* bump `ghcr.io/devcontainers/features/common-utils` from 2.5.1 to 2.5.2
* bump `ghcr.io/devcontainers/features/node` from 1.6.0 to 1.6.1
