### PR TITLE
feat(wordpress): more control over what happens in `updateContentCommand`

### DIFF
--- a/features/src/wordpress/devcontainer-feature.json
+++ b/features/src/wordpress/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "wordpress",
     "name": "WordPress",
     "description": "Sets up WordPress into the Dev Environment",
-    "version": "2.6.4",
+    "version": "2.7.0",
     "documentationURL": "https://github.com/Automattic/vip-codespaces/tree/trunk/features/src/wordpress",
     "containerEnv": {
         "WP_CLI_CONFIG_PATH": "/etc/wp-cli/wp-cli.yaml"

--- a/features/src/wordpress/wordpress-update-content.sh
+++ b/features/src/wordpress/wordpress-update-content.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -f composer.json ] && [ -x /usr/local/bin/composer ]; then
+if [ -z "${WPUC_SKIP_COMPOSER_INSTALL:-}" ] && [ -f composer.json ] && [ -x /usr/local/bin/composer ]; then
     MY_UID="$(id -un)"
     if [ 0 -eq "${MY_UID}" ]; then
         export COMPOSER_ALLOW_SUPERUSER=1
@@ -9,10 +9,10 @@ if [ -f composer.json ] && [ -x /usr/local/bin/composer ]; then
     /usr/local/bin/composer install -n || true
 fi
 
-if [ -f package.json ] && hash npm >/dev/null 2>&1; then
+if [ -z "${WPUC_SKIP_NPM_INSTALL:-}" ] && [ -f package.json ] && hash npm >/dev/null 2>&1; then
     if [ ! -d node_modules ] && [ -f package-lock.json ]; then
-        npm ci
+        npm ci || true
     else
-        npm install
+        npm install || true
     fi
 fi


### PR DESCRIPTION
  * Introduce `WPUC_SKIP_COMPOSER_INSTALL` and `WPUC_SKIP_NPM_INSTALL` environment variables to optionally skip `composer/npm install` steps;
  * Failures during `npm install` won't prevent the container from starting.
