### PR TITLE
fix(wordpress): set `SUNRISE` for multisites

### DIFF
--- a/features/src/wordpress/devcontainer-feature.json
+++ b/features/src/wordpress/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "wordpress",
     "name": "WordPress",
     "description": "Sets up WordPress into the Dev Environment",
-    "version": "2.7.0",
+    "version": "2.7.1",
     "documentationURL": "https://github.com/Automattic/vip-codespaces/tree/trunk/features/src/wordpress",
     "containerEnv": {
         "WP_CLI_CONFIG_PATH": "/etc/wp-cli/wp-cli.yaml"

--- a/features/src/wordpress/setup-wordpress.sh
+++ b/features/src/wordpress/setup-wordpress.sh
@@ -99,6 +99,7 @@ if [ -n "${multisite_domain}" ]; then
     else
         wp config set SUBDOMAIN_INSTALL true --raw --config-file=/wp/config/wp-config.php
     fi
+    wp config set SUNRISE true --raw  --config-file=/wp/config/wp-config.php
 fi
 wp config shuffle-salts --config-file=/wp/config/wp-config.php
 


### PR DESCRIPTION
Set `SUNRISE` to `true` for multisite installations.

See BB8-12188 and [Configuration for local development](https://docs.wpvip.com/wordpress-on-vip/multisites/sunrise-php/#h-configuration-for-local-development).

Related: Automattic/vip-container-images#1061
