### PR TITLE
ci: add AI Changelog workflow

### DIFF
--- a/.github/workflows/ai-changelog.yml
+++ b/.github/workflows/ai-changelog.yml
@@ -1,0 +1,77 @@
+name: Generate Changelog for PR
+
+on:
+  issue_comment:
+    types:
+      - created
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    name: Generate Changelog for PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: >
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/changelog'
+    steps:
+      - name: Verify OpenAI API Key is available
+        run: |
+          if [ -z "${OPENAI_API_KEY}" ]; then
+            echo "OPENAI_API_KEY is not set."
+            exit 1
+          fi
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Check if user has write access
+        id: check_access
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const { data: membership } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login
+            });
+            if (membership.permission !== 'write' && membership.permission !== 'admin' && membership.permission !== 'maintain') {
+              core.setFailed(`User ${context.payload.comment.user.login} does not have write access.`);
+            } else {
+              core.setOutput("authorized", 'true');
+            }
+
+      - name: Generate Changelog Entry
+        if: steps.check_access.outputs.authorized == 'true'
+        id: changelog
+        uses: Automattic/vip-actions/ai-changelog@429a448961152b194fd94df2ce9c82fc293e3ec7 # trunk
+        with:
+          pr_number: ${{ github.event.issue.number }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3.1.0
+        if: steps.check_access.outputs.authorized == 'true'
+        id: fc
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## AI-Generated Changelog Entry'
+
+      - name: Post Changelog Comment
+        if: >
+          steps.check_access.outputs.authorized == 'true' &&
+          steps.changelog.outputs.changelog-entry
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ## AI-Generated Changelog Entry
+
+            ${{ steps.changelog.outputs.changelog-entry }}
+
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically generate changelog entries for pull requests using an AI-powered tool. The workflow is triggered by a specific comment (`/changelog`) on a pull request and ensures that only authorized users can execute it.

### New GitHub Actions Workflow:

* [`.github/workflows/ai-changelog.yml`](diffhunk://#diff-fe648599046a6c383677ee87dfeaed869eb7108a6f5652aea9c920804b25926dR1-R77): Added a workflow named "Generate Changelog for PR" that listens for `issue_comment` events. It verifies the presence of the OpenAI API key, checks if the user has write access, generates a changelog entry using the AI tool, and posts or updates a comment with the generated entry.