### PR TITLE
fix(wpvip-integrations-base): install Playwright browsers

### DIFF
--- a/images/src/wpvip-integrations-base/.devcontainer.json
+++ b/images/src/wpvip-integrations-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "WPVIP Integrations",
         "image-name": "wpvip-integrations-base",
-        "image-version": "0.0.1"
+        "image-version": "0.0.2"
     },
     "remoteUser": "vscode",
     "updateContentCommand": "/usr/local/bin/update-content.sh",

--- a/images/src/wpvip-integrations-base/update-content.sh
+++ b/images/src/wpvip-integrations-base/update-content.sh
@@ -6,3 +6,7 @@ if [ -d node_modules ]; then
 else
     npm ci
 fi
+
+if npm ls playwright > /dev/null; then
+    npx playwright install
+fi


### PR DESCRIPTION
This pull request updates the development container configuration and improves the setup process for Playwright in the `wpvip-integrations-base` image.

**Playwright setup automation:**

* Modified `update-content.sh` to automatically install Playwright browsers if the `playwright` package is present in `node_modules`, streamlining the setup for end-to-end testing.