### PR TITLE
fix(php): do not install `php81-intl` on Alpine due to conflicts

### DIFF
--- a/features/src/php/devcontainer-feature.json
+++ b/features/src/php/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "php",
     "name": "PHP",
     "description": "Installs PHP into the Dev Environment",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "documentationURL": "https://github.com/Automattic/vip-codespaces/tree/trunk/features/src/php",
     "options": {
         "version": {

--- a/features/src/php/install.sh
+++ b/features/src/php/install.sh
@@ -19,7 +19,7 @@ PHP_VERSION="${VERSION}"
 
 setup_php81_alpine() {
     if [ "${LITE_INSTALL}" != 'true' ]; then
-        EXTENSIONS="icu-data-full ghostscript php81-bcmath php81-intl php81-pecl-mcrypt php81-soap php81-pecl-igbinary php81-pecl-ssh2 php81-pecl-timezonedb"
+        EXTENSIONS="icu-data-full ghostscript php81-bcmath php81-pecl-mcrypt php81-soap php81-pecl-igbinary php81-pecl-ssh2 php81-pecl-timezonedb"
     else
         EXTENSIONS=
     fi


### PR DESCRIPTION
This pull request makes a minor update to the PHP devcontainer feature, primarily focused on package management. The most notable change is the removal of the `php81-intl` extension from the default set of installed PHP extensions for Alpine environments.

Package management updates:

* Removed the `php81-intl` extension from the default list of PHP extensions installed in Alpine environments in `install.sh` to address compatibility issues.
* Bumped the feature version from `2.8.0` to `2.8.1` in `devcontainer-feature.json` to reflect this change.