### PR TITLE
feat: add `ubuntu-cross` image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,8 @@ updates:
     package-ecosystem: devcontainers
     schedule:
       interval: daily
+
+  - directory: tools/ubuntu-cross
+    package-ecosystem: docker
+    schedule:
+      interval: daily

--- a/.github/workflows/ubuntu-cross.yml
+++ b/.github/workflows/ubuntu-cross.yml
@@ -1,0 +1,61 @@
+name: Build ubuntu-cross Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    paths: 
+      - '.github/workflows/ubuntu-cross.yml'
+      - 'tools/ubuntu-cross/**'
+  pull_request:
+    paths: 
+      - '.github/workflows/ubuntu-cross.yml'
+      - 'tools/ubuntu-cross/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ubuntu-cross
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: https://ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ github.base_ref == null }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: push
+        with:
+          context: .
+          file: ./tools/ubuntu-cross/Dockerfile
+          push: ${{ github.base_ref == null }}
+          tags: ghcr.io/automattic/vip-codespaces/ubuntu-cross:latest
+          cache-from: type=gha,scope=ubuntu-cross
+          cache-to: type=gha,mode=max,scope=ubuntu-cross
+          no-cache: ${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Attest provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-name: ghcr.io/automattic/vip-codespaces/ubuntu-cross
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+        if: ${{ github.base_ref == null }}

--- a/tools/ubuntu-cross/Dockerfile
+++ b/tools/ubuntu-cross/Dockerfile
@@ -1,0 +1,17 @@
+FROM --platform=${BUILDPLATFORM} tonistiigi/xx:master@sha256:bb6377a9163e77e2d9f73a4615c3ee0470c25a3be1c371b706740757a07ec381 AS xx
+FROM --platform=${BUILDPLATFORM} ubuntu:noble@sha256:9cbed754112939e914291337b5e554b07ad7c392491dba6daf25eef1332a22e8 AS build
+COPY --from=xx / /
+
+RUN <<EOF
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update
+    apt-get install -y --no-install-recommends eatmydata
+    eatmydata apt-get install -y --no-install-recommends clang make
+    rm -rf /var/lib/apt/lists/*
+    for i in linux/arm linux/arm64 linux/386 linux/amd64; do
+        TARGETPLATFORM="${i}" xx-clang --setup-target-triple
+        TARGETPLATFORM="${i}" eatmydata xx-apt-get install -y gcc g++ libc6-dev libstdc++-13-dev
+    done
+EOF
+
+WORKDIR /src


### PR DESCRIPTION
This pull request introduces a new Docker-based cross-compilation toolchain for Ubuntu and automates its build and maintenance within the repository. The main changes include adding a new Dockerfile for building cross-compilation images, setting up a dedicated GitHub Actions workflow to build and publish the image, and updating Dependabot to monitor the new Docker setup for dependency updates.

**New cross-compilation tooling:**

* Added a new `Dockerfile` in `tools/ubuntu-cross` that builds an Ubuntu-based image with cross-compilers for multiple architectures using `xx-clang` and installs essential build tools. (`tools/ubuntu-cross/Dockerfile`)

**CI/CD automation:**

* Created a new GitHub Actions workflow (`.github/workflows/ubuntu-cross.yml`) to build, cache, and push the `ubuntu-cross` Docker image to GitHub Container Registry, including provenance attestation.

**Dependency management:**

* Updated `.github/dependabot.yml` to include the new `tools/ubuntu-cross` Docker setup, ensuring automated dependency updates for the cross-compilation tooling.