### PR TITLE
chore(wpvip-base): update fearures

### DIFF
--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -10,10 +10,10 @@
       "resolved": "ghcr.io/devcontainers-extra/features/composer@sha256:92bd9a7d6b294cdf231e7c4c36897da20e09e65d580db516d768c8b309496a76",
       "integrity": "sha256:92bd9a7d6b294cdf231e7c4c36897da20e09e65d580db516d768c8b309496a76"
     },
-    "ghcr.io/devcontainers/features/common-utils:2.5.3": {
-      "version": "2.5.3",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85",
-      "integrity": "sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85"
+    "ghcr.io/devcontainers/features/common-utils:2.5.4": {
+      "version": "2.5.4",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:00fd45550f578d9d515044d9e2226e908dbc3d7aa6fcb9dee4d8bdb60be114cf",
+      "integrity": "sha256:00fd45550f578d9d515044d9e2226e908dbc3d7aa6fcb9dee4d8bdb60be114cf"
     },
     "ghcr.io/devcontainers/features/git:1.3.3": {
       "version": "1.3.3",

--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -15,10 +15,10 @@
       "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85",
       "integrity": "sha256:3cf7ca93154faf9bdb128f3009cf1d1a91750ec97cc52082cf5d4edef5451f85"
     },
-    "ghcr.io/devcontainers/features/git:1.3.3": {
-      "version": "1.3.3",
-      "resolved": "ghcr.io/devcontainers/features/git@sha256:d2d768ecc06f6b71ecd0820408c6272de2cc24427fe07921d93ede5c7775ad1d",
-      "integrity": "sha256:d2d768ecc06f6b71ecd0820408c6272de2cc24427fe07921d93ede5c7775ad1d"
+    "ghcr.io/devcontainers/features/git:1.3.4": {
+      "version": "1.3.4",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:f24645e64ad39a596131a50ec96f7d5cf7a2a87544cce772dd4b7182a233e98a",
+      "integrity": "sha256:f24645e64ad39a596131a50ec96f7d5cf7a2a87544cce772dd4b7182a233e98a"
     },
     "ghcr.io/devcontainers/features/github-cli:1.0.14": {
       "version": "1.0.14",

--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -25,10 +25,10 @@
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:ca677566507c4118e4368cd76a4800807e911e5e350cc3525fb67ebc9132dfa1",
       "integrity": "sha256:ca677566507c4118e4368cd76a4800807e911e5e350cc3525fb67ebc9132dfa1"
     },
-    "ghcr.io/devcontainers/features/node:1.6.2": {
-      "version": "1.6.2",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:36c03732c3421f11de7a3eefc7e9a7fb3df123cb2e48b115d61fdfe8994911d9",
-      "integrity": "sha256:36c03732c3421f11de7a3eefc7e9a7fb3df123cb2e48b115d61fdfe8994911d9"
+    "ghcr.io/devcontainers/features/node:1.6.3": {
+      "version": "1.6.3",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:3c35dff2aedeaeb86f03e10c265c29b56a1b3609324d83d6e901dbb6032543a4",
+      "integrity": "sha256:3c35dff2aedeaeb86f03e10c265c29b56a1b3609324d83d6e901dbb6032543a4"
     }
   }
 }

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -20,7 +20,7 @@
         },
         "ghcr.io/devcontainers/features/git:1.3.3": {},
         "ghcr.io/devcontainers/features/github-cli:1.0.14": {},
-        "ghcr.io/devcontainers/features/node:1.6.2": {},
+        "ghcr.io/devcontainers/features/node:1.6.3": {},
         "ghcr.io/devcontainers-contrib/features/composer:1.0.1": {},
         "ghcr.io/automattic/vip-codespaces/wp-cli:1.2.0": {},
         "./.devcontainer/local-features/sudo": {}

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "WPVIP",
         "image-name": "wpvip-base",
-        "image-version": "0.0.20"
+        "image-version": "0.0.21"
     },
     "remoteUser": "vscode",
     "postStartCommand": "/usr/local/bin/post-start.sh",

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -18,7 +18,7 @@
             "upgradePackages": true,
             "username": "vscode"
         },
-        "ghcr.io/devcontainers/features/git:1.3.3": {},
+        "ghcr.io/devcontainers/features/git:1.3.4": {},
         "ghcr.io/devcontainers/features/github-cli:1.0.14": {},
         "ghcr.io/devcontainers/features/node:1.6.2": {},
         "ghcr.io/devcontainers-contrib/features/composer:1.0.1": {},

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -11,7 +11,7 @@
     "remoteUser": "vscode",
     "postStartCommand": "/usr/local/bin/post-start.sh",
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.3": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.4": {
             "installZsh": false,
             "installOhMyZsh": false,
             "installOhMyZshConfig": false,


### PR DESCRIPTION
This pull request updates the development container configuration for `wpvip-base` to use newer versions of several devcontainer features and increments the image version. These updates help ensure the development environment is using the latest tools and security patches.

Dependency and configuration updates:

* Updated the `common-utils` feature from version 2.5.3 to 2.5.4 in both `.devcontainer.json` and `.devcontainer-lock.json`. [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R23) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL13-R31)
* Updated the `git` feature from version 1.3.3 to 1.3.4 in both `.devcontainer.json` and `.devcontainer-lock.json`. [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R23) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL13-R31)
* Updated the `node` feature from version 1.6.2 to 1.6.3 in both `.devcontainer.json` and `.devcontainer-lock.json`. [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R23) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL13-R31)

Version bump:

* Incremented the `image-version` for the `wpvip-base` image from `0.0.20` to `0.0.21` in `.devcontainer.json` to reflect these updates.