### PR TITLE
fix(php): remove cron from rc2.d for Debian

### DIFF
--- a/features/src/php/devcontainer-feature.json
+++ b/features/src/php/devcontainer-feature.json
@@ -2,13 +2,13 @@
     "id": "php",
     "name": "PHP",
     "description": "Installs PHP into the Dev Environment",
-    "version": "2.8.1",
+    "version": "2.8.0",
     "documentationURL": "https://github.com/Automattic/vip-codespaces/tree/trunk/features/src/php",
     "options": {
         "version": {
             "type": "string",
             "enum": ["8.0", "8.1", "8.2", "8.3", "8.4"],
-            "default": "8.2",
+            "default": "8.3",
             "description": "PHP version"
         },
         "composer": {

--- a/features/src/php/devcontainer-feature.json
+++ b/features/src/php/devcontainer-feature.json
@@ -2,7 +2,7 @@
     "id": "php",
     "name": "PHP",
     "description": "Installs PHP into the Dev Environment",
-    "version": "2.8.0",
+    "version": "2.9.0",
     "documentationURL": "https://github.com/Automattic/vip-codespaces/tree/trunk/features/src/php",
     "options": {
         "version": {

--- a/features/src/php/install.sh
+++ b/features/src/php/install.sh
@@ -312,6 +312,7 @@ setup_php81_deb() {
 
     # shellcheck disable=SC2086
     eatmydata apt-get install -y --no-install-recommends \
+        anacron \
         php8.1-cli php8.1-fpm \
         php8.1-apcu php8.1-curl php8.1-gd php8.1-gmp php8.1-mbstring \
         php8.1-memcache php8.1-memcached php8.1-mysql php8.1-sqlite3 php8.1-xml php8.1-zip ${EXTENSIONS}
@@ -338,7 +339,8 @@ setup_php81_deb() {
     fi
 
     update-rc.d -f php8.1-fpm remove
-    update-rc.d -f cron remove
+    update-rc.d -f anacron remove
+    rm -f /etc/cron.*/*anacron
 }
 
 setup_php82_deb() {
@@ -354,6 +356,7 @@ setup_php82_deb() {
 
     # shellcheck disable=SC2086
     eatmydata apt-get install -y --no-install-recommends \
+        anacron \
         php8.2-cli php8.2-fpm \
         php8.2-apcu php8.2-curl php8.2-gd php8.2-gmp php8.2-mbstring \
         php8.2-memcache php8.2-memcached php8.2-mysql php8.2-sqlite3 php8.2-xml php8.2-zip ${EXTENSIONS}
@@ -380,7 +383,8 @@ setup_php82_deb() {
     fi
 
     update-rc.d -f php8.2-fpm remove
-    update-rc.d -f cron remove
+    update-rc.d -f anacron remove
+    rm -f /etc/cron.*/*anacron
 }
 
 setup_php83_deb() {
@@ -396,6 +400,7 @@ setup_php83_deb() {
 
     # shellcheck disable=SC2086
     eatmydata apt-get install -y --no-install-recommends \
+        anacron \
         php8.3-cli php8.3-fpm \
         php8.3-apcu php8.3-curl php8.3-gd php8.3-gmp php8.3-mbstring \
         php8.3-memcache php8.3-memcached php8.3-mysql php8.3-sqlite3 php8.3-xml php8.3-zip ${EXTENSIONS}
@@ -422,7 +427,8 @@ setup_php83_deb() {
     fi
 
     update-rc.d -f php8.3-fpm remove
-    update-rc.d -f cron remove
+    update-rc.d -f anacron remove
+    rm -f /etc/cron.*/*anacron
 }
 
 setup_php84_deb() {
@@ -438,6 +444,7 @@ setup_php84_deb() {
 
     # shellcheck disable=SC2086
     eatmydata apt-get install -y --no-install-recommends \
+        anacron \
         php8.4-cli php8.4-fpm \
         php8.4-apcu php8.4-curl php8.4-gd php8.4-gmp php8.4-mbstring \
         php8.4-memcache php8.4-memcached php8.4-mysql php8.4-sqlite3 php8.4-xml php8.4-zip ${EXTENSIONS}
@@ -464,7 +471,8 @@ setup_php84_deb() {
     fi
 
     update-rc.d -f php8.4-fpm remove
-    update-rc.d -f cron remove
+    update-rc.d -f anacron remove
+    rm -f /etc/cron.*/*anacron
 }
 
 echo "(*) Installing PHP ${PHP_VERSION}..."

--- a/features/src/php/install.sh
+++ b/features/src/php/install.sh
@@ -338,6 +338,7 @@ setup_php81_deb() {
     fi
 
     update-rc.d -f php8.1-fpm remove
+    update-rc.d -f cron remove
 }
 
 setup_php82_deb() {
@@ -379,6 +380,7 @@ setup_php82_deb() {
     fi
 
     update-rc.d -f php8.2-fpm remove
+    update-rc.d -f cron remove
 }
 
 setup_php83_deb() {
@@ -420,6 +422,7 @@ setup_php83_deb() {
     fi
 
     update-rc.d -f php8.3-fpm remove
+    update-rc.d -f cron remove
 }
 
 setup_php84_deb() {
@@ -461,6 +464,7 @@ setup_php84_deb() {
     fi
 
     update-rc.d -f php8.4-fpm remove
+    update-rc.d -f cron remove
 }
 
 echo "(*) Installing PHP ${PHP_VERSION}..."


### PR DESCRIPTION
This pull request updates the PHP devcontainer feature to version 2.9.0 and introduces improvements to the installation scripts for PHP 8.1 through 8.4. The main changes ensure that `anacron` is explicitly installed and then removed adequately from system startup and cron directories for each PHP version, improving consistency and avoiding unnecessary background jobs in the dev environment.

**Devcontainer metadata update:**

* Bumped the `version` in `devcontainer-feature.json` from 2.8.1 to 2.9.0 and changed the default PHP version to 8.3.

**PHP installation and cleanup improvements:**

* Added `anacron` to the list of packages installed for PHP 8.1, 8.2, 8.3, and 8.4 in `install.sh` to ensure its presence before cleanup. [[1]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R315) [[2]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R359) [[3]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R403) [[4]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R447)
* After installation, explicitly remove `anacron` from system startup and delete related cron files for each PHP version to prevent unwanted scheduled tasks. [[1]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R342-R343) [[2]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R386-R387) [[3]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R430-R431) [[4]](diffhunk://#diff-05c1c4746dc3d13a43346f576030ba0a940b40cbc6d7939ea95a3ce8a12d6712R474-R475)