### PR TITLE
chore(ubuntu-base): update features

### DIFF
--- a/base-images/src/ubuntu-base/.devcontainer-lock.json
+++ b/base-images/src/ubuntu-base/.devcontainer-lock.json
@@ -1,19 +1,19 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/common-utils:2.5.5": {
-      "version": "2.5.5",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:6d22e5475de578a8dadf19ce15c0ed09d82d8e3006b851dae7fe59a959c9b787",
-      "integrity": "sha256:6d22e5475de578a8dadf19ce15c0ed09d82d8e3006b851dae7fe59a959c9b787"
+    "ghcr.io/devcontainers/features/common-utils:2.5.6": {
+      "version": "2.5.6",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:9ddad2e4f71f172cc0bf28461e70948218f70f8ad6cd936b5c8dbe0a8acf6b45",
+      "integrity": "sha256:9ddad2e4f71f172cc0bf28461e70948218f70f8ad6cd936b5c8dbe0a8acf6b45"
     },
-    "ghcr.io/devcontainers/features/git:1.3.4": {
-      "version": "1.3.4",
-      "resolved": "ghcr.io/devcontainers/features/git@sha256:f24645e64ad39a596131a50ec96f7d5cf7a2a87544cce772dd4b7182a233e98a",
-      "integrity": "sha256:f24645e64ad39a596131a50ec96f7d5cf7a2a87544cce772dd4b7182a233e98a"
+    "ghcr.io/devcontainers/features/git:1.3.5": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
-    "ghcr.io/devcontainers/features/github-cli:1.0.15": {
-      "version": "1.0.15",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf",
-      "integrity": "sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf"
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     }
   }
 }

--- a/base-images/src/ubuntu-base/.devcontainer.json
+++ b/base-images/src/ubuntu-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "Ubuntu",
         "image-name": "ubuntu-base",
-        "image-version": "0.0.41"
+        "image-version": "0.0.42"
     },
     "remoteUser": "vscode",
     "containerEnv": {
@@ -19,15 +19,15 @@
         "SHELL": "/bin/bash"
     },
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.5": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.6": {
             "installZsh": false,
             "installOhMyZsh": false,
             "installOhMyZshConfig": false,
             "upgradePackages": true,
             "username": "vscode"
         },
-        "ghcr.io/devcontainers/features/github-cli:1.0.15": {},
-        "ghcr.io/devcontainers/features/git:1.3.4": {},
+        "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
+        "ghcr.io/devcontainers/features/git:1.3.5": {},
         "./.devcontainer/local-features/sudo": {},
         "./.devcontainer/local-features/cleanup": {},
         "./.devcontainer/local-features/syslog": {}


### PR DESCRIPTION
This pull request updates the development container configuration for the Ubuntu base image to use newer versions of several devcontainer features and increments the image version. These changes ensure the container uses the latest improvements and bug fixes from upstream dependencies.

Dependency updates:

* Upgraded `common-utils` feature from version `2.5.5` to `2.5.6` in both `.devcontainer.json` and `.devcontainer-lock.json` to get the latest utilities and fixes. [[1]](diffhunk://#diff-cebe1bf5d8e12d0f40d3995ca1258e605ff809e2fb77917eec189327b5a34498L22-R30) [[2]](diffhunk://#diff-6ce7b71daf717fe3c26c971332ba4dffed65211a79aa0c044e606f0e2bcc1ad4L3-R16)
* Upgraded `github-cli` feature from version `1.0.15` to `1.1.0` in both `.devcontainer.json` and `.devcontainer-lock.json` for the latest GitHub CLI enhancements. [[1]](diffhunk://#diff-cebe1bf5d8e12d0f40d3995ca1258e605ff809e2fb77917eec189327b5a34498L22-R30) [[2]](diffhunk://#diff-6ce7b71daf717fe3c26c971332ba4dffed65211a79aa0c044e606f0e2bcc1ad4L3-R16)
* Upgraded `git` feature from version `1.3.4` to `1.3.5` in both `.devcontainer.json` and `.devcontainer-lock.json` for the latest Git improvements. [[1]](diffhunk://#diff-cebe1bf5d8e12d0f40d3995ca1258e605ff809e2fb77917eec189327b5a34498L22-R30) [[2]](diffhunk://#diff-6ce7b71daf717fe3c26c971332ba4dffed65211a79aa0c044e606f0e2bcc1ad4L3-R16)

Configuration update:

* Incremented the base image version from `0.0.41` to `0.0.42` in `.devcontainer.json` to reflect these dependency updates.