### PR TITLE
chore(wpvip-base): update features

### DIFF
--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -5,30 +5,30 @@
       "resolved": "ghcr.io/automattic/vip-codespaces/wp-cli@sha256:fbeac1e95f0898138d645135401ea642859d1ad69bf1f87e3d0c64a54bca97d0",
       "integrity": "sha256:fbeac1e95f0898138d645135401ea642859d1ad69bf1f87e3d0c64a54bca97d0"
     },
-    "ghcr.io/devcontainers-contrib/features/composer:1.0.1": {
+    "ghcr.io/devcontainers-extra/features/composer:1.0.1": {
       "version": "1.0.1",
       "resolved": "ghcr.io/devcontainers-extra/features/composer@sha256:92bd9a7d6b294cdf231e7c4c36897da20e09e65d580db516d768c8b309496a76",
       "integrity": "sha256:92bd9a7d6b294cdf231e7c4c36897da20e09e65d580db516d768c8b309496a76"
     },
-    "ghcr.io/devcontainers/features/common-utils:2.5.5": {
-      "version": "2.5.5",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:6d22e5475de578a8dadf19ce15c0ed09d82d8e3006b851dae7fe59a959c9b787",
-      "integrity": "sha256:6d22e5475de578a8dadf19ce15c0ed09d82d8e3006b851dae7fe59a959c9b787"
+    "ghcr.io/devcontainers/features/common-utils:2.5.6": {
+      "version": "2.5.6",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:9ddad2e4f71f172cc0bf28461e70948218f70f8ad6cd936b5c8dbe0a8acf6b45",
+      "integrity": "sha256:9ddad2e4f71f172cc0bf28461e70948218f70f8ad6cd936b5c8dbe0a8acf6b45"
     },
-    "ghcr.io/devcontainers/features/git:1.3.4": {
-      "version": "1.3.4",
-      "resolved": "ghcr.io/devcontainers/features/git@sha256:f24645e64ad39a596131a50ec96f7d5cf7a2a87544cce772dd4b7182a233e98a",
-      "integrity": "sha256:f24645e64ad39a596131a50ec96f7d5cf7a2a87544cce772dd4b7182a233e98a"
+    "ghcr.io/devcontainers/features/git:1.3.5": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
     },
-    "ghcr.io/devcontainers/features/github-cli:1.0.15": {
-      "version": "1.0.15",
-      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf",
-      "integrity": "sha256:1ad1ec1a806cc9926c84ca5b147427bba03b97e14e91f9df89af83726039ecaf"
+    "ghcr.io/devcontainers/features/github-cli:1.1.0": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/devcontainers/features/node:1.6.3": {
-      "version": "1.6.3",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:3c35dff2aedeaeb86f03e10c265c29b56a1b3609324d83d6e901dbb6032543a4",
-      "integrity": "sha256:3c35dff2aedeaeb86f03e10c265c29b56a1b3609324d83d6e901dbb6032543a4"
+    "ghcr.io/devcontainers/features/node:1.7.0": {
+      "version": "1.7.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:e2fe58e98b235779e253224dd6dd78acb7a4de79efd9b9b210b1785846c09170",
+      "integrity": "sha256:e2fe58e98b235779e253224dd6dd78acb7a4de79efd9b9b210b1785846c09170"
     }
   }
 }

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -6,22 +6,22 @@
     "x-build": {
         "name": "WPVIP",
         "image-name": "wpvip-base",
-        "image-version": "0.0.22"
+        "image-version": "0.0.23"
     },
     "remoteUser": "vscode",
     "postStartCommand": "/usr/local/bin/post-start.sh",
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.5": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.6": {
             "installZsh": false,
             "installOhMyZsh": false,
             "installOhMyZshConfig": false,
             "upgradePackages": true,
             "username": "vscode"
         },
-        "ghcr.io/devcontainers/features/git:1.3.4": {},
-        "ghcr.io/devcontainers/features/github-cli:1.0.15": {},
-        "ghcr.io/devcontainers/features/node:1.6.3": {},
-        "ghcr.io/devcontainers-contrib/features/composer:1.0.1": {},
+        "ghcr.io/devcontainers/features/git:1.3.5": {},
+        "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
+        "ghcr.io/devcontainers/features/node:1.7.0": {},
+        "ghcr.io/devcontainers-extra/features/composer:1.0.1": {},
         "ghcr.io/automattic/vip-codespaces/wp-cli:1.2.0": {},
         "./.devcontainer/local-features/sudo": {}
     },
@@ -31,7 +31,7 @@
         "ghcr.io/devcontainers/features/git",
         "ghcr.io/devcontainers/features/github-cli",
         "ghcr.io/devcontainers/features/node",
-        "ghcr.io/devcontainers-contrib/features/composer",
+        "ghcr.io/devcontainers-extra/features/composer",
         "ghcr.io/automattic/vip-codespaces/wp-cli"
     ],
     "customizations": {


### PR DESCRIPTION
This pull request updates the development container configuration for the `wpvip-base` image. The main focus is upgrading several devcontainer features to their latest versions and switching the Composer feature source to improve compatibility and support.

Dependency and feature updates:

* Upgraded the following devcontainer features to newer versions for improved functionality and security: `common-utils` (2.5.5 → 2.5.6), `git` (1.3.4 → 1.3.5), `github-cli` (1.0.15 → 1.1.0), and `node` (1.6.3 → 1.7.0). [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R24) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL8-R31)
* Changed the Composer feature source from `ghcr.io/devcontainers-contrib/features/composer` to `ghcr.io/devcontainers-extra/features/composer` for better support and maintenance. [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R24) [[2]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L34-R34) [[3]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL8-R31)

Configuration versioning:

* Updated the `image-version` for the `wpvip-base` devcontainer from `0.0.22` to `0.0.23` to reflect these changes.