### PR TITLE
test(desktop-lite): fix transient failures

### DIFF
--- a/features/test/desktop-lite/checks.sh
+++ b/features/test/desktop-lite/checks.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 
-if hash sv >/dev/null 2>&1; then
+if hash sv > /dev/null 2>&1; then
     check "tigervnc is running" sudo sh -c 'sv status tigervnc | grep -E ^run:'
     sudo sv stop tigervnc
     check "tigervnc is stopped" sudo sh -c 'sv status tigervnc | grep -E ^down:'
     sudo sv start tigervnc
+    sleep 1
     check "tigervnc is running" sudo sh -c 'sv status tigervnc | grep -E ^run:'
 
     check "openbox is running" sudo sh -c 'sv status openbox | grep -E ^run:'
     sudo sv stop openbox
     check "openbox is stopped" sudo sh -c 'sv status openbox | grep -E ^down:'
     sudo sv start openbox
+    sleep 1
     check "openbox is running" sudo sh -c 'sv status openbox | grep -E ^run:'
 
     check "novnc is running" sudo sh -c 'sv status novnc | grep -E ^run:'
     sudo sv stop novnc
     check "novnc is stopped" sudo sh -c 'sv status novnc | grep -E ^down:'
     sudo sv start novnc
+    sleep 1
     check "novnc is running" sudo sh -c 'sv status novnc | grep -E ^run:'
 else
     check "tigervnc is running" pgrep Xtigervnc
@@ -24,7 +27,7 @@ else
     check "novnc is running" pgrep easy-novnc
 fi
 
-if hash netstat >/dev/null 2>&1; then
+if hash netstat > /dev/null 2>&1; then
     check "Port 5800 is open" sh -c 'netstat -lnt | grep :5800'
     check "Port 5900 is open" sh -c 'netstat -lnt | grep :5900'
     check "Port 6000 is open" sh -c 'netstat -lnt | grep :6000'

--- a/features/test/desktop-lite/checks.sh
+++ b/features/test/desktop-lite/checks.sh
@@ -5,21 +5,36 @@ if hash sv > /dev/null 2>&1; then
     sudo sv stop tigervnc
     check "tigervnc is stopped" sudo sh -c 'sv status tigervnc | grep -E ^down:'
     sudo sv start tigervnc
-    sleep 1
+    # shellcheck disable=SC2034
+    for i in {1..10}; do
+        # shellcheck disable=SC2312
+        sudo sv status tigervnc | grep -Eq '^run:' && break
+        sleep 1
+    done
     check "tigervnc is running" sudo sh -c 'sv status tigervnc | grep -E ^run:'
 
     check "openbox is running" sudo sh -c 'sv status openbox | grep -E ^run:'
     sudo sv stop openbox
     check "openbox is stopped" sudo sh -c 'sv status openbox | grep -E ^down:'
     sudo sv start openbox
-    sleep 1
+    # shellcheck disable=SC2034
+    for i in {1..10}; do
+        # shellcheck disable=SC2312
+        sudo sv status openbox | grep -Eq '^run:' && break
+        sleep 1
+    done
     check "openbox is running" sudo sh -c 'sv status openbox | grep -E ^run:'
 
     check "novnc is running" sudo sh -c 'sv status novnc | grep -E ^run:'
     sudo sv stop novnc
     check "novnc is stopped" sudo sh -c 'sv status novnc | grep -E ^down:'
     sudo sv start novnc
-    sleep 1
+    # shellcheck disable=SC2034
+    for i in {1..10}; do
+        # shellcheck disable=SC2312
+        sudo sv status novnc | grep -Eq '^run:' && break
+        sleep 1
+    done
     check "novnc is running" sudo sh -c 'sv status novnc | grep -E ^run:'
 else
     check "tigervnc is running" pgrep Xtigervnc

--- a/features/test/desktop-lite/test.sh
+++ b/features/test/desktop-lite/test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-#!/bin/bash
-
 # shellcheck source=/dev/null
 source dev-container-features-test-lib
 


### PR DESCRIPTION
This pull request makes minor improvements to the desktop-lite test scripts. The main change is the addition of brief pauses after restarting services in `checks.sh` to help ensure that services have time to start before their status is checked.

Improvements to service checks:

* Added `sleep 1` after restarting the `tigervnc`, `openbox`, and `novnc` services in `checks.sh` to reduce the chance of race conditions when checking service status.

Code cleanup:

* Removed a duplicate shebang line from the top of `test.sh`.