### PR TITLE
test(desktop-lite): add debug info for flaky tests

### DIFF
--- a/features/test/desktop-lite/checks.sh
+++ b/features/test/desktop-lite/checks.sh
@@ -13,6 +13,11 @@ if hash sv > /dev/null 2>&1; then
     done
     check "tigervnc is running" sudo sh -c 'sv status tigervnc | grep -E ^run:'
 
+    # shellcheck disable=SC2312
+    if ! sudo sv status openbox | grep -E ^run:; then
+        sudo ps faux
+        sudo cat /var/log/*
+    fi
     check "openbox is running" sudo sh -c 'sv status openbox | grep -E ^run:'
     sudo sv stop openbox
     check "openbox is stopped" sudo sh -c 'sv status openbox | grep -E ^down:'
@@ -23,6 +28,11 @@ if hash sv > /dev/null 2>&1; then
         sudo sv status openbox | grep -Eq '^run:' && break
         sleep 1
     done
+    # shellcheck disable=SC2312
+    if ! sudo sv status openbox | grep -E ^run:; then
+        sudo ps faux
+        sudo cat /var/log/*
+    fi
     check "openbox is running" sudo sh -c 'sv status openbox | grep -E ^run:'
 
     check "novnc is running" sudo sh -c 'sv status novnc | grep -E ^run:'


### PR DESCRIPTION
This pull request adds additional debugging steps to the `features/test/desktop-lite/checks.sh` script to help diagnose issues when the `openbox` service fails to start.

Debugging improvements:

* [`features/test/desktop-lite/checks.sh`](diffhunk://#diff-a712cc4e8692b80f4f03c56f7fe506887f56450d307143c156f721589ff838a7R26-R29): Added a conditional block to output running processes (`ps faux`) and the contents of all log files in `/var/log` if the `openbox` service is not running, providing more information for troubleshooting test failures.