### PR TITLE
fix(vip-cli): install `npm` explicitly

### DIFF
--- a/features/src/vip-cli/devcontainer-feature.json
+++ b/features/src/vip-cli/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "id": "vip-cli",
     "name": "VIP-CLI",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Installs VIP-CLI into the Dev Environment",
     "options": {
         "enabled": {

--- a/features/src/vip-cli/install.sh
+++ b/features/src/vip-cli/install.sh
@@ -18,7 +18,7 @@ if [ "${ENABLED}" = "true" ]; then
     install -d -D -m 0755 /usr/local/etc/vscode-dev-containers/vip-codespaces/vip-cli
     install -m 0644 devcontainer-feature.json devcontainer-features.env /usr/local/etc/vscode-dev-containers/vip-codespaces/vip-cli/
 
-    if ! hash node >/dev/null 2>&1 || ! hash npm >/dev/null 2>&1; then
+    if ! hash node > /dev/null 2>&1 || ! hash npm > /dev/null 2>&1; then
         # shellcheck source=/dev/null
         . /etc/os-release
 
@@ -29,13 +29,13 @@ if [ "${ENABLED}" = "true" ]; then
             "debian")
                 export DEBIAN_FRONTEND=noninteractive
 
-                if ! hash node >/dev/null 2>&1 || ! hash npm >/dev/null 2>&1 || ! hash npx >/dev/null 2>&1; then
+                if ! hash node > /dev/null 2>&1 || ! hash npm > /dev/null 2>&1 || ! hash npx > /dev/null 2>&1; then
                     PACKAGES=""
-                    if ! hash curl >/dev/null 2>&1; then
+                    if ! hash curl > /dev/null 2>&1; then
                         PACKAGES="${PACKAGES} curl"
                     fi
 
-                    if ! hash update-ca-certificates >/dev/null 2>&1; then
+                    if ! hash update-ca-certificates > /dev/null 2>&1; then
                         PACKAGES="${PACKAGES} ca-certificates"
                     fi
 
@@ -48,23 +48,23 @@ if [ "${ENABLED}" = "true" ]; then
                     curl -fsSL https://deb.nodesource.com/setup_lts.x -o nodesource_setup.sh
                     chmod +x nodesource_setup.sh
                     ./nodesource_setup.sh
-                    apt-get install -y nodejs
+                    apt-get install -y nodejs npm
 
                     apt-get clean
                     rm -rf /var/lib/apt/lists/*
                 fi
-            ;;
+                ;;
 
             "alpine")
-                if ! hash node >/dev/null 2>&1 || ! hash npm >/dev/null 2>&1; then
+                if ! hash node > /dev/null 2>&1 || ! hash npm > /dev/null 2>&1; then
                     apk add --no-cache nodejs npm
                 fi
-            ;;
+                ;;
 
             *)
                 echo "(!) Unsupported distribution: ${ID}"
                 exit 1
-            ;;
+                ;;
         esac
     fi
 


### PR DESCRIPTION
This pull request makes a minor update to the VIP-CLI devcontainer feature, primarily addressing a dependency installation issue for Node.js. The most important change is ensuring that both `nodejs` and `npm` are installed in the development environment.

Dependency installation fix:

* Modified the installation script (`features/src/vip-cli/install.sh`) to install both `nodejs` and `npm` instead of just `nodejs`, ensuring that the Node.js package manager is available in the dev environment.

Version bump:

* Updated the version number in `features/src/vip-cli/devcontainer-feature.json` from `1.5.0` to `1.5.1` to reflect the change.