### PR TITLE
fix(mariadb): address deprecations

### DIFF
--- a/features/src/mariadb/devcontainer-feature.json
+++ b/features/src/mariadb/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "MariaDB",
     "id": "mariadb",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "Sets up MariaDB into the Dev Environment",
     "options": {
         "installDatabaseToWorkspaces": {

--- a/features/src/mariadb/entrypoint.alpine.tpl
+++ b/features/src/mariadb/entrypoint.alpine.tpl
@@ -12,13 +12,13 @@ chown -R "${MARIADB_USER}:${MARIADB_USER}" "${MARIADB_DATADIR}"
 install -d /run/mysqld -o "${MARIADB_USER}" -g "${MARIADB_USER}"
 
 if [ ! -d "${MARIADB_DATADIR}/mysql" ]; then
-    mysql_install_db --auth-root-authentication-method=normal --skip-test-db --user="${MARIADB_USER}" --datadir="${MARIADB_DATADIR}"
+    mariadb-install-db --auth-root-authentication-method=normal --skip-test-db --user="${MARIADB_USER}" --datadir="${MARIADB_DATADIR}"
 fi
 
 if [ -x /sbin/chpst ]; then
     # shellcheck disable=SC2086,SC2154 # there could be multiple options in EXTRA_OPTIONS
     exec chpst -u "${MARIADB_USER}:${MARIADB_USER}" \
-        mysqld \
+        mariadbd \
             --datadir="${MARIADB_DATADIR}" \
             --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION \
             --max_allowed_packet=67M \
@@ -27,7 +27,7 @@ if [ -x /sbin/chpst ]; then
 else
     # shellcheck disable=SC2086 # there could be multiple options in EXTRA_OPTIONS
     exec su-exec "${MARIADB_USER}:${MARIADB_USER}" \
-        mysqld \
+        mariadbd \
             --datadir="${MARIADB_DATADIR}" \
             --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION \
             --max_allowed_packet=67M \

--- a/features/src/mariadb/entrypoint.deb.tpl
+++ b/features/src/mariadb/entrypoint.deb.tpl
@@ -12,7 +12,7 @@ chown -R "${MARIADB_USER}:${MARIADB_USER}" "${MARIADB_DATADIR}"
 install -d /run/mysqld -o "${MARIADB_USER}" -g "${MARIADB_USER}"
 
 if [ ! -d "${MARIADB_DATADIR}/mysql" ]; then
-    mysql_install_db --auth-root-authentication-method=normal --skip-test-db --user="${MARIADB_USER}" --datadir="${MARIADB_DATADIR}"
+    mariadb-install-db --auth-root-authentication-method=normal --skip-test-db --user="${MARIADB_USER}" --datadir="${MARIADB_DATADIR}"
 fi
 
 MY_UID="$(id -u "${MARIADB_USER}")"
@@ -20,7 +20,7 @@ MY_GID="$(id -g "${MARIADB_USER}")"
 
 # shellcheck disable=SC2086,SC2154 # there could be multiple options in EXTRA_OPTIONS
 exec setpriv --reuid="${MY_UID}" --regid="${MY_GID}" --inh-caps=-all --init-groups \
-    mysqld \
+    mariadbd \
         --datadir="${MARIADB_DATADIR}" \
         --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION \
         --max_allowed_packet=67M \

--- a/features/src/mariadb/service-run.tpl
+++ b/features/src/mariadb/service-run.tpl
@@ -12,12 +12,12 @@ chown -R "${MARIADB_USER}:${MARIADB_USER}" "${MARIADB_DATADIR}"
 install -d /run/mysqld -o "${MARIADB_USER}" -g "${MARIADB_USER}"
 
 if [ ! -d "${MARIADB_DATADIR}/mysql" ]; then
-    mysql_install_db --auth-root-authentication-method=normal --skip-test-db --user="${MARIADB_USER}" --datadir="${MARIADB_DATADIR}"
+    mariadb-install-db --auth-root-authentication-method=normal --skip-test-db --user="${MARIADB_USER}" --datadir="${MARIADB_DATADIR}"
 fi
 
 # shellcheck disable=SC2086,SC2154 # there could be multiple options in EXTRA_OPTIONS
 exec chpst -u "${MARIADB_USER}:${MARIADB_USER}" \
-    mysqld \
+    mariadbd \
         --datadir="${MARIADB_DATADIR}" \
         --sql-mode=ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION \
         --max_allowed_packet=67M \

--- a/features/test/mariadb/checks.sh
+++ b/features/test/mariadb/checks.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-if hash sv >/dev/null 2>&1; then
+second=0
+while ! mariadb-admin ping -u root -h 127.0.0.1 --silent && [[ "${second}" -lt 60 ]]; do
+    sleep 1
+    second=$((second + 1))
+done
+check "MariaDB is online" mariadb-admin ping -u root -h 127.0.0.1 --silent
+
+if hash sv > /dev/null 2>&1; then
     check "mariadb is running" sudo sh -c 'sv status mariadb | grep -E ^run:'
     sudo sv stop mariadb
     check "mariadb is stopped" sudo sh -c 'sv status mariadb | grep -E ^down:'
@@ -8,13 +15,6 @@ if hash sv >/dev/null 2>&1; then
 else
     check "mariadb is running" pgrep mariadbd
 fi
-
-second=0
-while ! mysqladmin ping -u root -h 127.0.0.1 --silent && [[ "${second}" -lt 60 ]]; do
-    sleep 1
-    second=$((second+1))
-done
-check "MariaDB is online" mysqladmin ping -u root -h 127.0.0.1 --silent
 
 # Microsoft's base images contain zsh. We don't want to run this check for MS images because we have no control over the installed services.
 if test -d /etc/rc2.d && ! test -e /usr/bin/zsh; then


### PR DESCRIPTION
This pull request updates the MariaDB devcontainer feature to use the correct MariaDB-specific binaries and commands, ensuring better compatibility and alignment with upstream MariaDB. It also improves the test script to use the proper MariaDB client tools and makes the startup check more robust.

**MariaDB binary and command alignment:**
- Replaced all uses of `mysql_install_db` with `mariadb-install-db` in entrypoint and service scripts to use the MariaDB-specific initialization tool. [[1]](diffhunk://#diff-07b3d725363fbb1b33274c036e4892a4b5cbfab90791d6984dacf05f6275c6f0L15-R21) [[2]](diffhunk://#diff-b84297a0a0733d8ccfd6446a68a3530cde8ec9e2c21cb4c8f990215e009351beL15-R23) [[3]](diffhunk://#diff-9849b5d1f3b37c6d460b16080f00577290e0580334e3b6533c696acb77e7182bL15-R20)
- Updated all invocations of the server binary from `mysqld` to `mariadbd` for consistency with MariaDB best practices. [[1]](diffhunk://#diff-07b3d725363fbb1b33274c036e4892a4b5cbfab90791d6984dacf05f6275c6f0L15-R21) [[2]](diffhunk://#diff-07b3d725363fbb1b33274c036e4892a4b5cbfab90791d6984dacf05f6275c6f0L30-R30) [[3]](diffhunk://#diff-b84297a0a0733d8ccfd6446a68a3530cde8ec9e2c21cb4c8f990215e009351beL15-R23) [[4]](diffhunk://#diff-9849b5d1f3b37c6d460b16080f00577290e0580334e3b6533c696acb77e7182bL15-R20)

**Testing improvements:**
- Modified the test script (`checks.sh`) to use `mariadb-admin` instead of `mysqladmin` for health checks, and improved the wait loop to ensure MariaDB is online before proceeding. [[1]](diffhunk://#diff-800a04c3d35a2b7b7cb4a18beea2cf8f840482583a886958db6af57c77451254R3-R9) [[2]](diffhunk://#diff-800a04c3d35a2b7b7cb4a18beea2cf8f840482583a886958db6af57c77451254L12-L18)

**Version update:**
- Bumped the feature version in `devcontainer-feature.json` from `1.4.0` to `1.4.1` to reflect these changes.