### PR TITLE
chore(ubunntu-base): update features to current versions

### DIFF
--- a/base-images/src/ubuntu-base/.devcontainer-lock.json
+++ b/base-images/src/ubuntu-base/.devcontainer-lock.json
@@ -1,14 +1,14 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/common-utils:2.5.7": {
-      "version": "2.5.7",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
-      "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
+    "ghcr.io/devcontainers/features/common-utils:2.5.9": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
     },
-    "ghcr.io/devcontainers/features/git:1.3.5": {
-      "version": "1.3.5",
-      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
-      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    "ghcr.io/devcontainers/features/git:1.3.8": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
     },
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "1.1.0",

--- a/base-images/src/ubuntu-base/.devcontainer.json
+++ b/base-images/src/ubuntu-base/.devcontainer.json
@@ -6,7 +6,7 @@
     "x-build": {
         "name": "Ubuntu",
         "image-name": "ubuntu-base",
-        "image-version": "0.0.43"
+        "image-version": "0.0.44"
     },
     "remoteUser": "vscode",
     "containerEnv": {
@@ -19,7 +19,7 @@
         "SHELL": "/bin/bash"
     },
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.7": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.9": {
             "installZsh": false,
             "installOhMyZsh": false,
             "installOhMyZshConfig": false,
@@ -27,7 +27,7 @@
             "username": "vscode"
         },
         "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
-        "ghcr.io/devcontainers/features/git:1.3.5": {},
+        "ghcr.io/devcontainers/features/git:1.3.8": {},
         "./.devcontainer/local-features/sudo": {},
         "./.devcontainer/local-features/cleanup": {},
         "./.devcontainer/local-features/syslog": {}


### PR DESCRIPTION
This pull request updates the development container configuration for the Ubuntu base image to use newer versions of the `common-utils` and `git` features, and increments the image version. These changes ensure the container uses the latest features and security updates.

**Dev container feature updates:**

* Updated `ghcr.io/devcontainers/features/common-utils` from version `2.5.7` to `2.5.9` in both `.devcontainer.json` and `.devcontainer-lock.json` to incorporate the latest utilities and fixes. [[1]](diffhunk://#diff-cebe1bf5d8e12d0f40d3995ca1258e605ff809e2fb77917eec189327b5a34498L22-R30) [[2]](diffhunk://#diff-6ce7b71daf717fe3c26c971332ba4dffed65211a79aa0c044e606f0e2bcc1ad4L3-R11)
* Updated `ghcr.io/devcontainers/features/git` from version `1.3.5` to `1.3.8` in both `.devcontainer.json` and `.devcontainer-lock.json` for improved Git support and bug fixes. [[1]](diffhunk://#diff-cebe1bf5d8e12d0f40d3995ca1258e605ff809e2fb77917eec189327b5a34498L22-R30) [[2]](diffhunk://#diff-6ce7b71daf717fe3c26c971332ba4dffed65211a79aa0c044e606f0e2bcc1ad4L3-R11)

**Versioning:**

* Bumped the `image-version` from `0.0.43` to `0.0.44` in `.devcontainer.json` to reflect the updated dependencies.