### PR TITLE
chore(wpvip-base): update features to current versions

### DIFF
--- a/images/src/wpvip-base/.devcontainer-lock.json
+++ b/images/src/wpvip-base/.devcontainer-lock.json
@@ -10,25 +10,25 @@
       "resolved": "ghcr.io/devcontainers-extra/features/composer@sha256:92bd9a7d6b294cdf231e7c4c36897da20e09e65d580db516d768c8b309496a76",
       "integrity": "sha256:92bd9a7d6b294cdf231e7c4c36897da20e09e65d580db516d768c8b309496a76"
     },
-    "ghcr.io/devcontainers/features/common-utils:2.5.7": {
-      "version": "2.5.7",
-      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
-      "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
+    "ghcr.io/devcontainers/features/common-utils:2.5.9": {
+      "version": "2.5.9",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a",
+      "integrity": "sha256:cb0c4d3c276f157eed17935747e364178d75fee17f55c4e129966f64633deb3a"
     },
-    "ghcr.io/devcontainers/features/git:1.3.5": {
-      "version": "1.3.5",
-      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
-      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    "ghcr.io/devcontainers/features/git:1.3.8": {
+      "version": "1.3.8",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2",
+      "integrity": "sha256:fd75977de13a9979000e0e78baf949adb0ca71d2398995fa22e0a36d7e7e7fe2"
     },
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/devcontainers/features/node:1.7.1": {
-      "version": "1.7.1",
-      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
-      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    "ghcr.io/devcontainers/features/node:2.1.0": {
+      "version": "2.1.0",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857",
+      "integrity": "sha256:586c9a6f7dd40bd3ba2cd41e7f2f88dcc31fbe5d1442afcbf07ffbc66b686857"
     }
   }
 }

--- a/images/src/wpvip-base/.devcontainer.json
+++ b/images/src/wpvip-base/.devcontainer.json
@@ -6,21 +6,21 @@
     "x-build": {
         "name": "WPVIP",
         "image-name": "wpvip-base",
-        "image-version": "0.0.26"
+        "image-version": "0.0.27"
     },
     "remoteUser": "vscode",
     "postStartCommand": "/usr/local/bin/post-start.sh",
     "features": {
-        "ghcr.io/devcontainers/features/common-utils:2.5.7": {
+        "ghcr.io/devcontainers/features/common-utils:2.5.9": {
             "installZsh": false,
             "installOhMyZsh": false,
             "installOhMyZshConfig": false,
             "upgradePackages": true,
             "username": "vscode"
         },
-        "ghcr.io/devcontainers/features/git:1.3.5": {},
+        "ghcr.io/devcontainers/features/git:1.3.8": {},
         "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
-        "ghcr.io/devcontainers/features/node:1.7.1": {},
+        "ghcr.io/devcontainers/features/node:2.1.0": {},
         "ghcr.io/devcontainers-extra/features/composer:1.0.1": {},
         "ghcr.io/automattic/vip-codespaces/wp-cli:1.2.0": {},
         "./.devcontainer/local-features/sudo": {}


### PR DESCRIPTION
This pull request updates the development container configuration for the `wpvip-base` image, primarily by bumping the versions of several devcontainer features and the image itself. These changes help ensure that the development environment uses the latest features and security updates.

**Devcontainer feature and image updates:**

* Updated the `image-version` for `wpvip-base` from `0.0.26` to `0.0.27` in `.devcontainer.json`.
* Upgraded the following devcontainer features in both `.devcontainer.json` and `.devcontainer-lock.json`:
  - `common-utils` from `2.5.7` to `2.5.9` [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R23) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL13-R31)
  - `git` from `1.3.5` to `1.3.8` [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R23) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL13-R31)
  - `node` from `1.7.1` to `2.1.0` [[1]](diffhunk://#diff-a5ad977ba301f36bfea91045a80b196431375648d52fea58cb39855213df1e84L9-R23) [[2]](diffhunk://#diff-f5bacbf6f97acb3d0a2baae184737871793f5dc2042f07f2645afb340b032b2aL13-R31)